### PR TITLE
Adds a Google Drive uploading script

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ By default, all output is the raw CSV format provided by the API. Some types sup
 ## Uploading to Google Drive
 
 1. Download `gdrive` from https://github.com/prasmussen/gdrive/releases.
+1. Make sure the `gdrive` and `cronometer-export` binaries are in the same directory as the `to-gdrive.bash` script.
+1. Fill in your information in `to-gdrive.bash`.
 1. Execute `to-gdrive.bash` once to test, and to provide the `gdrive` with
    permissions to your Google Drive.
 1. Use `echo "0 20 * * * ~/to-gdrive"| crontab -` to have the script run every

--- a/README.md
+++ b/README.md
@@ -58,3 +58,13 @@ Ouput is provided either to a file using the -o flag or to stdout.
 By default, all output is the raw CSV format provided by the API. Some types support a json output that can be enabled via the -f flag.
 
 `-f, --format string     The output format. (raw | json) (Only available on the servings type.) (default "raw")`
+
+## Uploading to Google Drive
+
+1. Download `gdrive` from https://github.com/prasmussen/gdrive/releases.
+1. Execute `to-gdrive.bash` once to test, and to provide the `gdrive` with
+   permissions to your Google Drive.
+1. Use `echo "0 20 * * * ~/to-gdrive"| crontab -` to have the script run every
+   day.
+   **This overwrites your crontab.** Use `(crontab -l ; echo ""0 20 * * *
+   ~/to-gdrive")| crontab -` to append instead

--- a/to-gdrive.bash
+++ b/to-gdrive.bash
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./cronometer-export -u <USERNAME> -p <PASSWORD> -e -0d -s -100m > cronometer.csv
+./gdrive upload -p <FOLDER-ID> cronometer.csv


### PR DESCRIPTION
Partially fixes https://github.com/jrmycanady/cronometer-export/issues/1.  The "running automatically" part I solved by running via cron on a free-tier Google Cloud VM instance.